### PR TITLE
Update README.md: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ brew install jq
 
 # for creating archive 
 # see also https://github.com/adbar/trafilatura
-brew instaall trafilatura
+brew install trafilatura
 ```
 
 ### Get Pocket consumer key


### PR DESCRIPTION
I've found a small typo in your README. `instaall` => `install`